### PR TITLE
Fix select for custom columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 test.db
 .DS_Store
+.vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sa-repository"
-version = "1.0.0"
+version = "1.0.1"
 description = "Repository pattern for SQLAlchemy models"
 readme = "README.md"
 authors = ["Gasper3 <trzecik65@gmail.com>"]

--- a/sa_repository/__init__.py
+++ b/sa_repository/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 
 from .base import BaseRepository

--- a/sa_repository/base.py
+++ b/sa_repository/base.py
@@ -71,7 +71,8 @@ class BaseRepository(t.Generic[T]):
         select: t.Tuple[ColumnElement] | None = None,
         order_by=None,
     ) -> sa.Select:
-        query = sa.select(select if select else self.MODEL_CLASS).where(*where_args).order_by(order_by)
+        query = sa.select(*select) if select else sa.select(self.MODEL_CLASS)
+        query = query.where(*where_args).order_by(order_by)
 
         if joins:
             for join in joins:


### PR DESCRIPTION
Passing columns like `get_query(select=(Model.attr1, Model.attr2))` caused error